### PR TITLE
Prazo do Bitcoin corrigido

### DIFF
--- a/taxas.md
+++ b/taxas.md
@@ -32,7 +32,7 @@ Necessário cadastro com número de CPF e e-mail de confirmação.
 |Rubrica|Tarifas / Taxas|Limite diário*|Prazos|
 |--- |--- |--- |--- |
 |Depósito em real|-|R$ 30.000,00|Até 24 horas úteis|
-|Depósito em bitcoin|-|3 confirmações da rede|
+|Depósito em bitcoin|-|-|3 confirmações da rede|
 |Saques para bancos conveniados|0,99%|R$ 30.000,00|Até 24 horas úteis|
 |Saques para demais bancos|R$ 9,00 + 0,99%|R$ 30.000,00|Até 24 horas úteis|
 |Saque em Bitcoin|0,0006 BTC + taxa variável de mineração|-|5 minutos a 24 horas úteis|


### PR DESCRIPTION
a tabela do prazo do bitcoin para conta verificada está meio... errada
https://brecoins.com.br/taxas
o prazo do bitcoin foi colocado em limite diário, quando deveria estar na coluna de prazo.